### PR TITLE
Add distribution through Component & NPM

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "randomColor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "http://llllll.li/randomColor/",
   "repository": {
     "type": "git",

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "randomColor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repo": "davidmerfield/randomColor",
   "description": "For generating attractive random colors",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "randomColor",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "For generating attractive random colors",
   "main": "randomColor.js",
   "directories": {


### PR DESCRIPTION
With the addition of a `component.json` & `package.json`, this will be available through pretty much every commonly used package manager. It'll work with both browser and NodeJS applications.

Component & Bower will both pick up new version releases by seeing Github releases, but npm requires you to run `npm publish` each time. By the way, you'll need to run `npm publish` after merging this in to do an initial release there as well. 
