### PR TITLE
Reset the `count` property when it's been used/removed.

### DIFF
--- a/randomColor.js
+++ b/randomColor.js
@@ -46,6 +46,8 @@
         colors.push(randomColor(options));
       }
 
+      options.count = totalColors;
+
       return colors;
     }
 


### PR DESCRIPTION
Currently if you have something like the following:

```
var colorRequest = { /* ... */ count: 10 };
var colors = randomColor(colorRequest);
```

`colorRequest`'s `count` property will be overwritten.
