### PR TITLE
Properly check `count` so that a list is returned for appropriate falsey values.

### DIFF
--- a/randomColor.js
+++ b/randomColor.js
@@ -35,12 +35,12 @@
     var H,S,B;
 
     // Check if we need to generate multiple colors
-    if (options.count) {
+    if (options.count != null) {
 
       var totalColors = options.count,
           colors = [];
 
-      options.count = false;
+      options.count = null;
 
       while (totalColors > colors.length) {
         colors.push(randomColor(options));


### PR DESCRIPTION
Currently if you do something like the following

```
var colors = randomColor({count: 0});
```

You get a single color instead of an empty list.

Wasn't sure what you wanted the behavior to be for booleans and strings, but I believe `false`, `"0"`, and any non-numeric string now return empty lists as well.
