### PR TITLE
add rgba and hsla

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ randomColor({
    format: 'rgb' // e.g. 'rgb(225,200,20)'
 });
 
+// Returns a dark RGB color with random alpha
+randomColor({
+   luminosity: 'dark',
+   format: 'rgba' // e.g. 'rgba(9, 1, 107, 0.6482447960879654)'
+});
+
+// Returns a light HSL color with random alpha
+randomColor({
+   luminosity: 'light',
+   format: 'hsla' // e.g. 'hsla(27, 88.99%, 81.83%, 0.6450211517512798)'
+});
+
 ```
 
 ### License

--- a/randomColor.js
+++ b/randomColor.js
@@ -161,12 +161,20 @@
         var hsl = HSVtoHSL(hsv);
         return 'hsl('+hsl[0]+', '+hsl[1]+'%, '+hsl[2]+'%)';
 
+      case 'hsla':
+        var hslColor = HSVtoHSL(hsv);
+        return 'hsla('+hslColor[0]+', '+hslColor[1]+'%, '+hslColor[2]+'%, ' + Math.random() + ')';
+
       case 'rgbArray':
         return HSVtoRGB(hsv);
 
       case 'rgb':
         var rgb = HSVtoRGB(hsv);
         return 'rgb(' + rgb.join(', ') + ')';
+
+      case 'rgba':
+        var rgbColor = HSVtoRGB(hsv);
+        return 'rgba(' + rgbColor.join(', ') + ', ' + Math.random() + ')';
 
       default:
         return HSVtoHex(hsv);


### PR DESCRIPTION
address https://github.com/davidmerfield/randomColor/issues/18

## what is this?

We wanted to have alpha values. Here is the asked for `rgba`. Double bonus! :sparkles: also added `hsla`

## how to test
does setting the format return `rgba` and `hsla` correctly?
```
// Returns a dark RGB color with random alpha
randomColor({
   luminosity: 'dark',
   format: 'rgba' // e.g. 'rgba(9, 1, 107, 0.6482447960879654)'
});

// Returns a light HSL color with random alpha
randomColor({
   luminosity: 'light',
   format: 'hsla' // e.g. 'hsla(27, 88.99%, 81.83%, 0.6450211517512798)'
});
```
