### PR TITLE
Change seeds so they work the first time they are passed in

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "randomcolor",
   "homepage": "http://llllll.li/randomColor/",
+  "version": "0.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/davidmerfield/randomColor.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "randomcolor",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "For generating attractive random colors",
   "main": "randomColor.js",
   "directories": {

--- a/randomColor.js
+++ b/randomColor.js
@@ -10,15 +10,15 @@
   // Support CommonJS
   } else if (typeof exports === 'object') {
     var randomColor = factory();
-    
+
     // Support NodeJS & Component, which allow module.exports to be a function
     if (typeof module === 'object' && module && module.exports) {
       exports = module.exports = randomColor;
     }
-    
+
     // Support CommonJS 1.1.1 spec
     exports.randomColor = randomColor;
-  
+
   // Support vanilla script loading
   } else {
     root.randomColor = factory();
@@ -37,7 +37,9 @@
 
   var randomColor = function(options) {
     options = options || {};
-    if (options.seed && !seed) seed = options.seed;
+    if (options.seed && !seed) {
+      seed = options.seed;
+    }
 
     var H,S,B;
 
@@ -55,9 +57,12 @@
 
       options.count = totalColors;
 
-      //Keep the seed constant between runs. 
-      if (options.seed) seed = options.seed;
-      
+      //Keep the seed constant between runs.
+      if (options.seed && totalColors != colors.length)
+        seed = options.seed;
+      else
+        seed = null
+
       return colors;
     }
 


### PR DESCRIPTION
### Bug Report

Currently the way randomColor works, a seed will work the very first time it's passed in, but if the seed changes, it uses the last seed that was passed in to generate the color(s), and *then* it sets the new seed, causing the wrong output.

Here's an example:

```js
randomColor({seed: 1, count: 10})
// Output:
['#8bd343', '#a31f44', '#f23aa5', '#25bfd1', '#b9dd5d', '#b2ffd3', '#017984', '#c4214f', '#fcd928', '#55dbd2']


randomColor({seed: 2, count: 10}) // Note the seed has changed from 1 to 2
// Notice that this is the same array as when it was seeded with "1"
['#8bd343', '#a31f44', '#f23aa5', '#25bfd1', '#b9dd5d', '#b2ffd3', '#017984', '#c4214f', '#fcd928', '#55dbd2']

randomColor({seed: 2, count: 10}) // Note the seed is still 2
// This is now the correct array of colors
['#7ed65e', '#d8d82f', '#46e2a1', '#77eaea', '#d062fc', '#8e6af2', '#604ce0', '#e5d177', '#9df2e2', '#efcb8d']
```

As you can see, when you run the generator with one seed (first run), change the seed, run it again (second run), it generates the wrong array of colors. Then when you run it for the third time (with the 
same seed as the second run), it generates the correct array of colors.

### Solution

This pull request modifies the behavior of the seed option so that the seed is reset at the end of each run.

I've also written a test that fails if you use the original version of randomColor (before my changes), so that you can run it (via `npm run test`) and easily see the bug.

#### Misc

I've also bumped the version number in package.json, as well as added a version number to the bower.json file. I also created a new tag for the 0.4.1 release (not sure if this will move over when my PR is merged in though…)