### PR TITLE
Add support for string seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can pass an options object to influence the type of color it produces. The o
 
 **Count** – An integer which specifies the number of colors to generate.
 
-**Seed** - An integer which when passed will cause randomColor to return the same color each time.
+**Seed** - An integer or string which when passed will cause randomColor to return the same color each time.
 
 **Format** – A string which specifies the format of the generated color. Possible values are ```rgb```, ```rgbArray```, ```hsl```, ```hslArray``` and ```hex``` (default).
 

--- a/randomColor.js
+++ b/randomColor.js
@@ -43,7 +43,11 @@
     if (options.seed && options.seed === parseInt(options.seed, 10)) {
       seed = options.seed;
 
-    // Something was passed as a seed but it wasn't an integer
+    // A string was passed as a seed
+    } else if (typeof options.seed === 'string') {
+      seed = stringToInteger(options.seed);
+
+    // Something was passed as a seed but it wasn't an integer or string
     } else if (options.seed !== undefined && options.seed !== null) {
       throw new TypeError('The seed value must be an integer');
 
@@ -409,6 +413,15 @@
       Math.round(s*v / (k<1 ? k : 2-k) * 10000) / 100,
       k/2 * 100
     ];
+  }
+
+  function stringToInteger (string) {
+    var total = 0
+    for (var i = 0; i !== string.length; i++) {
+      if (total >= Number.MAX_SAFE_INTEGER) break;
+      total += string.charCodeAt(i)
+    }
+    return total
   }
 
   return randomColor;


### PR DESCRIPTION
I'm working on an app that needs to use a string as a seed for a random colour, so I've added very basic support for that here. The `stringToInteger` function is very naive, but does the job of converting any given string to an integer to use as the true seed.