### PR TITLE
Ensure monochrome hue is honored correctly

### DIFF
--- a/randomColor.js
+++ b/randomColor.js
@@ -110,12 +110,12 @@
 
   function pickSaturation (hue, options) {
 
-    if (options.luminosity === 'random') {
-      return randomWithin([0,100]);
-    }
-
     if (options.hue === 'monochrome') {
       return 0;
+    }
+
+    if (options.luminosity === 'random') {
+      return randomWithin([0,100]);
     }
 
     var saturationRange = getSaturationRange(hue);


### PR DESCRIPTION
This PR fixes #79 by ensuring that the monochrome hue check runs *before* the random luminosity check.