### PR TITLE
Add `files` declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "type": "git",
     "url": "git://github.com/davidmerfield/randomColor.git"
   },
+  "files": [
+  ],
   "keywords": [
     "attractive",
     "random",


### PR DESCRIPTION
The current published package is 5MB. This is because it includes the
demo folder which also includes a whole host of node_modules.

By including a "files" key in the package.json - and setting it to an
empty array, this shrinks the publishable contents to 20kb - npm will
automatically include the README, LICENSE, and package.json#main
files, but will exclude any other files (including everything in
`demo`).