### PR TITLE
fix(package.json): use correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "generator"
   ],
   "author": "David Merfield",
-  "license": "CC0",
+  "license": "CC0-1.0",
   "homepage": "https://randomcolor.lllllllllllllllll.com/"
 }


### PR DESCRIPTION
Currently `license` field at `package.json` is specified as `CC0`, which is correct in terms of licensing, but is wrong in terms of spdx specification.

This patch uses correct identificator for "Creative Commons Zero v1.0 Universal" (`CC0-1.0`).

Source https://spdx.org/licenses/CC0-1.0.html

Without this patch some tools may fail to detect correct license for the package.